### PR TITLE
Add shorthand Mock::shouldReceive syntax

### DIFF
--- a/src/StaticMock.php
+++ b/src/StaticMock.php
@@ -46,7 +46,13 @@ class StaticMock {
      */
     public static function mock($class_name)
     {
-        return new Mock($class_name);
+        if (strpos($class_name, '::') === false) {
+            return new Mock($class_name);
+        }
+
+        list($class_name, $method_name) = explode('::', $class_name, 2);
+        $mock = new Mock($class_name);
+        return $mock->shouldReceive($method_name);
     }
 
 }

--- a/src/StaticMock/Mock.php
+++ b/src/StaticMock/Mock.php
@@ -137,7 +137,7 @@ class Mock {
         }
     }
 
-            /**
+    /**
      * @param string $message
      * @param $file_instance_created
      * @param $line_instance_created


### PR DESCRIPTION
## Before

```php
$mock = StaticMock::mock('Example')
    ->shouldRecive('staticMethod')
    ->andReturn('resultVal');
```

## After

```php
$mock = StaticMock::mock('Example::staticMethod')
    ->andReturn('resultVal');
```

## Why short syntax?

When grep codes for `Example::staticMethod`, never `mock('Example')->shouldRecive('staticMethod')` is detected.
