### PR TITLE
Update travis config to run tests with runkit7/runkit7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: php
 php:
+  - 7.1
+  - 7.0
   - 5.6
   - 5.5
   - 5.4
   - 5.3
+
 matrix:
   allow_failures:
     - php: 5.4
 
 before_script:
-  - pecl install runkit
+  - ci/install_runkit_for_php_version.sh
   - composer install
+
+script:
+  - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To install runkit, execute the following commands and add `extension=runkit.so` 
 pecl install runkit
 ```
 
-For PHP 7, Please try [TysonAndre/runkit7](https://github.com/TysonAndre/runkit7).
+For PHP 7, Please try [runkit7/runkit7](https://github.com/runkit7/runkit7).
 
 ## Install
 

--- a/ci/install_runkit_for_php_version.sh
+++ b/ci/install_runkit_for_php_version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -xeu
+# This script
+PHP_MAJOR_VERSION=$(php -r "echo PHP_MAJOR_VERSION;");
+
+if expr "$PHP_MAJOR_VERSION" ">=" "7" ; then
+	git clone --depth 1 https://github.com/runkit7/runkit7.git
+	pushd runkit7
+	phpize && ./configure && make && make install || exit 1
+	echo 'extension = runkit.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+	popd
+else
+	pecl install runkit
+fi


### PR DESCRIPTION
Update link in readme to the runkit7 repo with an issue tracker.

run unit tests in travis

- Use the phpunit version from composer.json, not the system-wide phpunit (optional)