### PR TITLE
Fix with() method when no arguments

### DIFF
--- a/src/StaticMock/Mock.php
+++ b/src/StaticMock/Mock.php
@@ -120,6 +120,9 @@ class Mock {
                     );
                 }
 
+            } elseif (count($this->shouldPassedArgs) === 0 && max(array_keys($passed_arguments)) + 1 !== 0) {
+                $actual = StringUtil::methodArgsToReadableString($passed_arguments);
+                throw $this->createAssertionFailException("Mocked method should be called with no argments but called with {$actual}");
             } else {
                 foreach ($passed_arguments as $k => $v) {
                     if (array_key_exists($k, $this->shouldPassedArgs)) {

--- a/test/StaticMock/MockTest.php
+++ b/test/StaticMock/MockTest.php
@@ -135,6 +135,26 @@ class MockTest extends \PHPUnit_Framework_TestCase
         $mock->assert();
     }
 
+    public function testPassedArgsAssertionThrowsExceptionWhenUnexepectedArgments0()
+    {
+        $mock = \StaticMock::mock('StaticMock\Car');
+        $mock->shouldReceive('boo')->times(1)->with();
+        $this->setExpectedException('\StaticMock\Exception\AssertionFailedException');
+        $p = new Person();
+        $p->drunk_drive();
+        $mock->assert();
+    }
+
+    public function testPassedArgsAssertionThrowsExceptionWhenUnexepectedArgments1()
+    {
+        $mock = \StaticMock::mock('StaticMock\Car');
+        $mock->shouldReceive('boo')->times(1)->with(1);
+        $this->setExpectedException('\StaticMock\Exception\AssertionFailedException');
+        $p = new Person();
+        $p->drive();
+        $mock->assert();
+    }
+
     public function testAndReturn()
     {
         $mock = \StaticMock::mock('StaticMock\Car');

--- a/test/StaticMock/Person.php
+++ b/test/StaticMock/Person.php
@@ -9,6 +9,11 @@ class Person {
         return Car::boo();
     }
 
+    public function drunk_drive()
+    {
+        return Car::boo(-1);
+    }
+
     public function warn($times)
     {
         return Car::beep($times);


### PR DESCRIPTION
`Staticmock::mock('Car::boo')->with()` means "expects called with no arguments", but current implementation did not detect that case.

Because `$this->shouldPassedArgs` is an empty array and null is distinguished, I think that this change is reasonable.

## Risk

Perhaps this change will break the tests of inexperienced users.
