### PR TITLE
handle pass-by-reference parameters.

### DIFF
--- a/src/StaticMock/Fake.php
+++ b/src/StaticMock/Fake.php
@@ -52,10 +52,10 @@ class Fake {
     public function getImplementation($implementation)
     {
         $that = $this;
-        return function () use ($implementation, $that) {
+        return function (&...$args) use ($implementation, $that) {
             Counter::getInstance()->increment($that->hash());
-            Arguments::getInstance()->record($that->hash(), func_get_args());
-            return call_user_func_array($implementation, func_get_args());
+            Arguments::getInstance()->record($that->hash(), ...$args);
+            return $implementation(...$args);
         };
     }
 

--- a/src/StaticMock/MethodReplacer/ClassManager.php
+++ b/src/StaticMock/MethodReplacer/ClassManager.php
@@ -83,16 +83,18 @@ class ClassManager implements Singleton {
     /**
      * Register the pseudo implementation
      *
-     * @param string $class_name
-     * @param string $method_name
+     * @param string   $class_name
+     * @param string   $method_name
      * @param callable $method_implementation
+     * @param callable $bear_implementation The closure as given to andImplementation()
+     * @throws \ReflectionException
      */
-    public function register($class_name, $method_name, \Closure $method_implementation)
+    public function register($class_name, $method_name, \Closure $method_implementation, \Closure $bear_implementation = null)
     {
         $this->managed_classes[$class_name] =
             $this
                 ->getManagedClassOrNewOne($class_name)
-                ->addMethod($method_name, $method_implementation);
+                ->addMethod($method_name, $method_implementation, $bear_implementation ?? $method_implementation);
     }
 
     /**

--- a/src/StaticMock/MethodReplacer/MethodInvoker.php
+++ b/src/StaticMock/MethodReplacer/MethodInvoker.php
@@ -46,12 +46,9 @@ class MethodInvoker {
      * @return mixed
      * @throws \StaticMock\Exception\MethodInvocationException
      */
-    public static function invoke($class_name, $method_name)
+    public static function invoke($class_name, $method_name, &...$method_args)
     {
-        $args = func_get_args();
-        $method_args = array_slice($args, 2);
-
-        $managed_class = ClassManager::getInstance()->getManagedClassOrNewOne($class_name);
+         $managed_class = ClassManager::getInstance()->getManagedClassOrNewOne($class_name);
 
         $fake_method = $managed_class->getMethod($method_name);
 
@@ -59,7 +56,7 @@ class MethodInvoker {
             throw new MethodInvocationException("Method not found! {$class_name}::{$method_name}");
         }
 
-        return call_user_func_array($fake_method, $method_args);
+        return $fake_method(...$method_args);
     }
 
 }

--- a/src/StaticMock/MethodReplacer/Parameter.php
+++ b/src/StaticMock/MethodReplacer/Parameter.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace StaticMock\MethodReplacer;
+
+
+class Parameter
+{
+    /**
+     * @var \ReflectionParameter
+     */
+    private $parameter;
+
+    public function __construct(\ReflectionParameter $parameter)
+    {
+        $this->parameter = $parameter;
+    }
+
+    public function getName(): string
+    {
+        return $this->parameter->getName();
+    }
+
+    public function getVar(): string
+    {
+        return '$' . $this->getName();
+    }
+
+    /**
+     * @return string
+     */
+    public function getArgString(): string
+    {
+        $s = $this->getVar();
+
+        if ($this->isVariadic()) {
+            $s = '...' . $s;
+        }
+        return $s;
+    }
+
+    /**
+     * @return string
+     * @throws \ReflectionException
+     */
+    public function getParamString(): string
+    {
+        $s = $this->getArgString();
+
+        if ($this->parameter->isPassedByReference()) {
+            $s = '&' . $s;
+        }
+
+        if ($this->parameter->isDefaultValueAvailable()) {
+            $s .= '=' . var_export($this->parameter->getDefaultValue(), true);
+        }
+
+        return $s;
+    }
+
+    public function isVariadic(): bool
+    {
+        return $this->parameter->isVariadic();
+    }
+
+    public function isPassedByReference(): bool
+    {
+        return $this->parameter->isPassedByReference();
+    }
+}
+

--- a/src/StaticMock/MethodReplacer/Parameters.php
+++ b/src/StaticMock/MethodReplacer/Parameters.php
@@ -1,0 +1,107 @@
+<?php
+
+
+namespace StaticMock\MethodReplacer;
+
+
+class Parameters
+{
+    /**
+     * @var \StaticMock\MethodReplacer\Parameter[]
+     */
+    private $parameters;
+
+    /**
+     * Parameters constructor.
+     *
+     * @param \StaticMock\MethodReplacer\Parameter[] $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        // Drop parameters that are not passed by reference at the end
+        for (;;) {
+            $c = count($parameters);
+            if ($c === 0 || $parameters[$c - 1]->isPassedByReference()) {
+                break;
+            }
+            array_pop($parameters);
+        }
+
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * Return the string to be used for the argument part of the function call.
+     *
+     * @return string
+     */
+    public function getArgString(): string
+    {
+        $strings = array_map(
+            function ($p) { return $p->getArgString(); },
+            $this->parameters
+        );
+
+        if ($this->isRequiredRestParameter()) {
+            array_push($strings, $this->getRestParameter());
+        }
+
+        return implode(',', $strings);
+    }
+
+    /**
+     * Returns the string to be used for the parameter part of the function definition.
+     *
+     * @return string
+     * @throws \ReflectionException
+     */
+    public function getParamString(): string
+    {
+        $strings = array_map(
+            function ($p) { return $p->getParamString(); },
+            $this->parameters
+        );
+
+        if ($this->isRequiredRestParameter()) {
+            array_push($strings, $this->getRestParameter());
+        }
+
+        return implode(',', $strings);
+    }
+
+    private function isRequiredRestParameter(): bool
+    {
+        $count = count($this->parameters);
+        return $count === 0 || !$this->parameters[$count - 1]->isVariadic();
+    }
+
+    private function getRestParameter(): string
+    {
+        $names = array_map(
+            function ($p) { return $p->getName(); },
+            $this->parameters
+        );
+
+        for ($i = 0; ; $i++) {
+            $rest_name = 'rest' . $i;
+            if (!in_array($rest_name, $names)) {
+                return '...$' . $rest_name;
+            }
+        }
+    }
+
+    /**
+     * @param $func
+     * @return static
+     * @throws \ReflectionException
+     */
+    public static function make($func): self
+    {
+        $parameters = array_map(
+            function ($rp) { return new Parameter($rp); },
+            (new \ReflectionFunction($func))->getParameters()
+        );
+
+        return new self($parameters);
+    }
+}

--- a/src/StaticMock/Mock.php
+++ b/src/StaticMock/Mock.php
@@ -192,7 +192,7 @@ class Mock {
             throw new \InvalidArgumentException("arguments should be a Closure");
         }
         $impl = $this->fake->getImplementation($implementation);
-        ClassManager::getInstance()->register($this->class_name, $this->method_name, $impl);
+        ClassManager::getInstance()->register($this->class_name, $this->method_name, $impl, $implementation);
         return $this;
     }
 

--- a/test/StaticMock/MethodReplacer/MethodReplaceableClassTest.php
+++ b/test/StaticMock/MethodReplacer/MethodReplaceableClassTest.php
@@ -23,7 +23,7 @@ class MethodReplaceableClassTest extends \PHPUnit\Framework\TestCase
         $method_name = 'a';
         $f = function () { return 1; };
         $class = new MethodReplaceableClass('\StaticMock\MethodReplacer\A');
-        $actual = $class->addMethod($method_name, $f);
+        $actual = $class->addMethod($method_name, $f, $f);
         $expected = $f;
         $this->assertEquals($expected, $actual->getMethod('a'));
     }
@@ -34,7 +34,7 @@ class MethodReplaceableClassTest extends \PHPUnit\Framework\TestCase
         $f = function () { return 1; };
         $class = new MethodReplaceableClass('StaticMock\MethodReplacer\A');
         $this->expectException('\StaticMock\Exception\MethodNotFoundException');
-        $class->addMethod($invalid_method_name, $f);
+        $class->addMethod($invalid_method_name, $f, $f);
     }
 
     public function testRemoveMethod()
@@ -42,7 +42,7 @@ class MethodReplaceableClassTest extends \PHPUnit\Framework\TestCase
         $method_name = 'a';
         $f = function () { return 1; };
         $class = new MethodReplaceableClass('\StaticMock\MethodReplacer\A');
-        $actual = $class->addMethod($method_name, $f)->removeMethod('a');
+        $actual = $class->addMethod($method_name, $f, $f)->removeMethod('a');
         $this->assertNull($actual->getMethod('a'));
     }
 

--- a/test/StaticMock/MethodReplacer/ParameterTest.php
+++ b/test/StaticMock/MethodReplacer/ParameterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace StaticMock\MethodReplacer;
+
+use PHPUnit\Framework\TestCase;
+
+class ParameterTest extends TestCase
+{
+    /**
+     * @throws \ReflectionException
+     */
+    public function testGetName()
+    {
+        $parameter = (new \ReflectionFunction(
+            function ($foo) {}
+        ))->getParameters()[0];
+
+        $target = new Parameter($parameter);
+
+        $this->assertSame('foo', $target->getName());
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    public function testGetVar()
+    {
+        $parameter = (new \ReflectionFunction(
+            function ($foo) {}
+        ))->getParameters()[0];
+
+        $target = new Parameter($parameter);
+
+        $this->assertSame('$foo', $target->getVar());
+    }
+
+    /**
+     * @param $expected
+     * @param $func
+     * @throws \ReflectionException
+     * @dataProvider getArgStringDataProvider
+     */
+    public function testGetArgString($expected, $func)
+    {
+        $parameter = (new \ReflectionFunction($func))->getParameters()[0];
+
+        $target = new Parameter($parameter);
+
+        $this->assertSame($expected, $target->getArgString());
+    }
+
+    public function getArgStringDataProvider(): array
+    {
+        return [
+            ['$foo', function ($foo) {}],
+            ['$foo', function (&$foo) {}],
+            ['...$foo', function (...$foo) {}],
+            ['...$foo', function (&...$foo) {}],
+            ['$foo', function ($foo = 1) {}],
+            ['$foo', function (&$foo = 1) {}],
+        ];
+    }
+
+    /**
+     * @param $expected
+     * @param $func
+     * @throws \ReflectionException
+     * @dataProvider getParamStringDataProvider
+     */
+    public function testGetParamString($expected, $func)
+    {
+        $parameter = (new \ReflectionFunction($func))->getParameters()[0];
+
+        $target = new Parameter($parameter);
+
+        $this->assertSame($expected, $target->getParamString());
+    }
+
+    public function getParamStringDataProvider(): array
+    {
+        return [
+            ['$foo', function ($foo) {}],
+            ['&$foo', function (&$foo) {}],
+            ['...$foo', function (...$foo) {}],
+            ['&...$foo', function (&...$foo) {}],
+            ['$foo=1', function ($foo = 1) {}],
+            ['&$foo=1', function (&$foo = 1) {}],
+        ];
+    }
+}

--- a/test/StaticMock/MethodReplacer/ParametersTest.php
+++ b/test/StaticMock/MethodReplacer/ParametersTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace StaticMock\MethodReplacer;
+
+use PHPUnit\Framework\TestCase;
+
+class ParametersTest extends TestCase
+{
+
+    /**
+     * @param $expected
+     * @param $func
+     * @dataProvider getParamStringDataProvider
+     * @throws \ReflectionException
+     */
+    public function testGetParamString($expected, $func)
+    {
+        $target = Parameters::make($func);
+        $this->assertSame($expected, $target->getParamString());
+    }
+
+    public function getParamStringDataProvider(): array
+    {
+        return [
+            ['...$rest0', function () {}],
+            ['...$rest0', function ($x, $y) {}],
+            ['&$x,...$rest0', function (&$x) {}],
+            ['$x,&$y,...$rest0', function ($x, &$y, $z) {}],
+            ['...$rest0', function ($x = 1) {}],
+            ['&$x=1,...$rest0', function (&$x = 1) {}],
+            ['$x=1,&$y=2,...$rest0', function ($x = 1, &$y = 2, $z = 3) {}],
+            ['$x,&...$y', function ($x, &...$y) {}],
+            ['$rest0,&$rest1,...$rest2', function ($rest0, &$rest1) {}],
+        ];
+    }
+
+    /**
+     * @param $expected
+     * @param $func
+     * @throws \ReflectionException
+     * @dataProvider getArgStringDataProvider
+     */
+    public function testGetArgString($expected, $func)
+    {
+        $target = Parameters::make($func);
+        $this->assertSame($expected, $target->getArgString());
+    }
+
+    public function getArgStringDataProvider(): array
+    {
+        return [
+            ['...$rest0', function () {}],
+            ['...$rest0', function ($x, $y) {}],
+            ['$x,...$rest0', function (&$x) {}],
+            ['$x,$y,...$rest0', function ($x, &$y, $z) {}],
+            ['...$rest0', function ($x = 1) {}],
+            ['$x,...$rest0', function (&$x = 1) {}],
+            ['$x,$y,...$rest0', function ($x = 1, &$y = 2, $z = 3) {}],
+            ['$x,...$y', function ($x, &...$y) {}],
+            ['$rest0,$rest1,...$rest2', function ($rest0, &$rest1) {}],
+        ];
+    }
+}

--- a/test/StaticMock/PassingByReferenceTarget.php
+++ b/test/StaticMock/PassingByReferenceTarget.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace StaticMock;
+
+class PassingByReferenceTarget
+{
+    public static function f(&$x) {}
+
+    public static function g(&...$x) {}
+
+    public static function h($x = 'a', &$y = 'b'): string { return ''; }
+}

--- a/test/StaticMock/PassingByReferenceTest.php
+++ b/test/StaticMock/PassingByReferenceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace StaticMock;
+
+use PHPUnit\Framework\TestCase;
+
+class PassingByReferenceTest extends TestCase
+{
+    public function testNormal()
+    {
+        $mock = \StaticMock::mock(PassingByReferenceTarget::class)
+            ->shouldReceive('f')
+            ->andImplement(function (&$x) {
+                $x = 100;
+            });
+
+        PassingByReferenceTarget::f($x);
+        $this->assertSame(100, $x);
+        $mock->assert();
+    }
+
+    public function testVariadic()
+    {
+        $mock = \StaticMock::mock(PassingByReferenceTarget::class)
+            ->shouldReceive('g')
+            ->andImplement(function (&...$x) {
+                $x[0] = 100;
+                $x[1] = 200;
+            });
+
+        PassingByReferenceTarget::g($x, $y);
+        $this->assertSame(100, $x);
+        $this->assertSame(200, $y);
+        $mock->assert();
+    }
+
+    public function testOptional()
+    {
+        $mock = \StaticMock::mock(PassingByReferenceTarget::class)
+            ->shouldReceive('h')
+            ->andImplement(function ($x = 'abc', &$y = 'def') {
+                return $x . $y;
+            });
+
+        $this->assertSame('abcdef', PassingByReferenceTarget::h());
+        $mock->assert();
+    }
+}


### PR DESCRIPTION
The current implementation does not handle pass-by-reference parameters well.
For example, the following error occurs.

```php
    public function testNormal()
    {
        $mock = \StaticMock::mock(PassingByReferenceTarget::class)
            ->shouldReceive('f')
            ->andImplement(function (&$x) {
                $x = 100;
            });

        PassingByReferenceTarget::f($x);
        $this->assertSame(100, $x);
        $mock->assert();
    }
```

```console
1) StaticMock\PassingByReferenceTest::testNormal
Parameter 1 to StaticMock\PassingByReferenceTest::StaticMock\{closure}() expected to be a reference, value given

/Users/matsui/work/staticmock/src/StaticMock/Fake.php:58
/Users/matsui/work/staticmock/src/StaticMock/MethodReplacer/MethodInvoker.php:62
/Users/matsui/work/staticmock/test/StaticMock/PassingByReferenceTest.php:17
```

This patch solves this problem.
