### PR TITLE
Deregister all methods even if multiple methods are registered.

### DIFF
--- a/src/StaticMock/Mock.php
+++ b/src/StaticMock/Mock.php
@@ -46,6 +46,8 @@ class Mock {
 
     private $method_name;
 
+    private $regidtered_method_names = [];
+
     private $fake;
 
     private $shouldCalledCount;
@@ -80,7 +82,9 @@ class Mock {
 
     public function __destruct()
     {
-        ClassManager::getInstance()->deregister($this->class_name, $this->method_name);
+        foreach ($this->regidtered_method_names as $method_name) {
+            ClassManager::getInstance()->deregister($this->class_name, $method_name);
+        }
         Counter::getInstance()->clear($this->fake->hash());
         Arguments::getInstance()->clear($this->fake->hash());
 
@@ -167,6 +171,9 @@ class Mock {
         $this->method_name = $method_name;
         $impl = $this->fake->getConstantImplementation(null);
         ClassManager::getInstance()->register($this->class_name, $this->method_name, $impl);
+        if (!in_array($method_name, $this->regidtered_method_names, true)) {
+            $this->regidtered_method_names[] = $method_name;
+        }
         return $this;
     }
 

--- a/test/StaticMock/MockTest.php
+++ b/test/StaticMock/MockTest.php
@@ -198,4 +198,17 @@ class MockTest extends \PHPUnit\Framework\TestCase
         $p->drive();
         $mock->assert();
     }
+
+    public function testMultipleShouldReceivePrepare() {
+        $mock = \StaticMock::mock('StaticMock\Car');
+        $mock->shouldReceive('boo')->andReturn('MockedBoo!');
+        $this->assertEquals('MockedBoo!', Car::boo());
+        $mock->shouldReceive('beep')->andReturn('MockedBeep!');
+        $this->assertEquals('MockedBeep!', Car::beep(1));
+    }
+
+    public function testMultipleShouldReceiveCheck() {
+        $this->assertNotEquals('MockedBoo!', Car::boo());
+        $this->assertNotEquals('MockedBeep!', Car::beep(1));
+    }
 }


### PR DESCRIPTION
When we mocked multiple methods by one Mock object, its destructor clear only the last one.
So, mock state of other methods remain in the next step.

@see test/StaticMock/MockTest.php::testMultipleShouldReceivePrepare & testMultipleShouldReceiveCheck

This PR solves this problem.
And, testMultipleShouldReceiveCheck is failure before this PR.

----------
Sample code.
```php
    $mock = \StaticMock::mock('StaticMock\Car');
    $mock->shouldReceive('boo')->andReturn('MockedBoo!');
    $this->assertEquals('MockedBoo!', Car::boo());
    $mock->shouldReceive('beep')->andReturn('MockedBeep!');
    $this->assertEquals('MockedBeep!', Car::beep(1));
    $mock = null;
```
Now, mocked beep is deregistered, but mocked boo remains.
And, this state obstacle after next test.