### PR TITLE
fix: remove unnecessary semicolon in PHPDoc to fix language server error

### DIFF
--- a/src/StaticMock/Mock.php
+++ b/src/StaticMock/Mock.php
@@ -170,7 +170,7 @@ class Mock
 
     /**
      * @param $return_value
-     * @return $this;
+     * @return $this
      */
     public function andReturn($return_value)
     {


### PR DESCRIPTION
> Expected type 'object'. Found '$this;'.

When I tried to chain method after `andReturn`, PHP intelephense (the PHP language server) will show an error.

It's caused by the unnecessary semicolon in PHPDoc, so I remove it.

Thank you for your project.